### PR TITLE
Prevented users from selecting the header button's text

### DIFF
--- a/Artifact2/Styles/standard.css
+++ b/Artifact2/Styles/standard.css
@@ -90,6 +90,7 @@ body {
 }
 .SiteHeaderButtonText {
     transform: skew(30deg);
+    user-select: none;
 }
 .RestrictWidth {
     margin: 0 auto;


### PR DESCRIPTION
Prevents the buttons at the top from being selected, making it act more like a button